### PR TITLE
1.2.3

### DIFF
--- a/ClientPlugin/Extensions/MyTerminalBlockExtensions.cs
+++ b/ClientPlugin/Extensions/MyTerminalBlockExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
@@ -6,6 +7,7 @@ using Sandbox.Game.Entities;
 using Sandbox.Game.Entities.Blocks;
 using Sandbox.Game.Entities.Cube;
 using Sandbox.Game.Screens.Helpers;
+using Sandbox.Game.World;
 using SpaceEngineers.Game.Entities.Blocks;
 using VRage.Utils;
 using VRageMath;
@@ -63,6 +65,13 @@ namespace ClientPlugin.Extensions
             {
                 try
                 {
+                    // Required since game version 1.208.014, because the default block names are now lazy-loaded
+                    // The following lines were copied from the MyTerminalBlock.CustomName getter:
+                    if (block.m_defaultCustomName.Length == 0 && MySession.Static != null && MySession.Static.Ready)
+                    {
+                        block.LoadDefaultCustomName();
+                    }
+                    
                     defaultName = block.m_defaultCustomName.ToString();
                     break;
                 }
@@ -77,6 +86,8 @@ namespace ClientPlugin.Extensions
             if (defaultName == null)
                 defaultName = "!See Better Terminal Issue #5!";
 
+            Debug.Assert(defaultName.Length != 0, "See the LoadDefaultCustomName call above, it did not work for some reason");
+            
             sb.Append(defaultName.TrimEnd());
             if (block is MyThrust thruster && thruster.GridThrustDirection != Vector3I.Zero)
             {

--- a/ClientPlugin/Properties/AssemblyInfo.cs
+++ b/ClientPlugin/Properties/AssemblyInfo.cs
@@ -32,8 +32,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.2.0")]
-[assembly: AssemblyFileVersion("1.2.2.0")]
+[assembly: AssemblyVersion("1.2.3.0")]
+[assembly: AssemblyFileVersion("1.2.3.0")]
 
 // Game assemblies to publicize
 [assembly: IgnoresAccessChecksTo("Sandbox.Game")]


### PR DESCRIPTION
Compatibility with game version 1.208.014

The default block names are now lazy-loaded. Since Keen hasn't added a proper `DefaultCustomName` get only property with the `LoadDefaultCustomName` call in it, the related code had to be copied into the plugin.